### PR TITLE
Added prefix for CSS classes and use CSS specificity to isolate all other styles

### DIFF
--- a/src/templates/category/index.html
+++ b/src/templates/category/index.html
@@ -1,6 +1,6 @@
 <h1><%- label %></h1>
 <p><%- description %></p>
-<ul class="category">
+<ul class="sd-category">
     <% _.forEach(items, function(item) { %>
     <li><a href="<%- baseUrl %>/docs/<%- item.path %>"><%- item.label %></a></li>
     <% }); %>

--- a/src/templates/category/index.ts
+++ b/src/templates/category/index.ts
@@ -3,7 +3,7 @@
  */
 const template = `<h1><%- label %></h1>
 <p><%- description %></p>
-<ul class="category">
+<ul class="sd-category">
     <% _.forEach(items, function(item) { %>
     <li><a href="<%- baseUrl %>/docs/<%- item.path %>"><%- item.label %></a></li>
     <% }); %>

--- a/src/templates/document/index.html
+++ b/src/templates/document/index.html
@@ -5,24 +5,20 @@
         <%= metaTemplate %> <%=
         styleTemplate %>
     </head>
-
-    <body class="docs">
-        <div class="mobile-overlay"></div>
+    <body class="static-docs">
+        <div class="sd-mobile-overlay"></div>
         <div>
             <%= toolbarTemplate %>
-
             <main>
                 <%= sidebar %>
-
-                <div class="container">
+                <div class="sd-container">
                     <%= versionInfo ?
                     versionInfo : "" %>
-                    <div class="content"><%= content %></div>
-                    <div class="index"><%= index %></div>
+                    <div class="sd-content"><%= content %></div>
+                    <div class="sd-index"><%= index %></div>
                 </div>
             </main>
         </div>
-
         <%= footerTemplate %>
     </body>
 </html>

--- a/src/templates/document/index.ts
+++ b/src/templates/document/index.ts
@@ -8,24 +8,20 @@ const template = `<!DOCTYPE html>
         <%= metaTemplate %> <%=
         styleTemplate %>
     </head>
-
-    <body class="docs">
-        <div class="mobile-overlay"></div>
+    <body class="static-docs">
+        <div class="sd-mobile-overlay"></div>
         <div>
             <%= toolbarTemplate %>
-
             <main>
                 <%= sidebar %>
-
-                <div class="container">
+                <div class="sd-container">
                     <%= versionInfo ?
                     versionInfo : "" %>
-                    <div class="content"><%= content %></div>
-                    <div class="index"><%= index %></div>
+                    <div class="sd-content"><%= content %></div>
+                    <div class="sd-index"><%= index %></div>
                 </div>
             </main>
         </div>
-
         <%= footerTemplate %>
     </body>
 </html>

--- a/src/templates/footer/index.html
+++ b/src/templates/footer/index.html
@@ -1,5 +1,5 @@
 <footer>
-    <div class="links">
+    <div class="sd-links">
         <div>
             <h3>Social</h3>
             <ul>

--- a/src/templates/footer/index.ts
+++ b/src/templates/footer/index.ts
@@ -2,7 +2,7 @@
  * Auto-generated file from build/generate-export-files.js
  */
 const template = `<footer>
-    <div class="links">
+    <div class="sd-links">
         <div>
             <h3>Social</h3>
             <ul>

--- a/src/templates/frontpage/index.html
+++ b/src/templates/frontpage/index.html
@@ -5,13 +5,13 @@
         <%= metaTemplate %> <%=
         styleTemplate %>
     </head>
-    <body>
-        <div class="mobile-overlay"></div>
+    <body class="static-docs">
+        <div class="sd-mobile-overlay"></div>
         <div>
             <%= toolbarTemplate %>
             <main>
-                <div class="container">
-                    <div class="content"><%= content %></div>
+                <div class="sd-container">
+                    <div class="sd-content"><%= content %></div>
                 </div>
             </main>
         </div>

--- a/src/templates/frontpage/index.ts
+++ b/src/templates/frontpage/index.ts
@@ -8,13 +8,13 @@ const template = `<!DOCTYPE html>
         <%= metaTemplate %> <%=
         styleTemplate %>
     </head>
-    <body>
-        <div class="mobile-overlay"></div>
+    <body class="static-docs">
+        <div class="sd-mobile-overlay"></div>
         <div>
             <%= toolbarTemplate %>
             <main>
-                <div class="container">
-                    <div class="content"><%= content %></div>
+                <div class="sd-container">
+                    <div class="sd-content"><%= content %></div>
                 </div>
             </main>
         </div>

--- a/src/templates/sidebar/index.html
+++ b/src/templates/sidebar/index.html
@@ -1,7 +1,7 @@
-<div class="sidebar">
-    <div class="mobile-control">
+<div class="sd-sidebar">
+    <div class="sd-mobile-control">
         <span><%- projectTitle %></span>
-        <button id="mobileClose" class="mobile-toggle">
+        <button id="mobileClose" class="sd-mobile-toggle">
             <svg viewBox="0 0 15 15" width="21" height="21">
                 <g stroke="#ccd0d5" stroke-width="1.2">
                     <path d="M.75.75l13.5 13.5M14.25.75L.75 14.25"></path>
@@ -14,7 +14,7 @@
             <% _.forEach(sidebar.links, function(documentationItem) { %>
             <li>
                 <a
-                    class="<%- documentationItem.path === currentPath ? 'active' : '' %>"
+                    class="<%- documentationItem.path === currentPath ? 'sd-active' : '' %>"
                     href="<%- baseUrl %>/docs/<%- documentationItem.path %>"
                 >
                     <%- documentationItem.label %>
@@ -24,7 +24,7 @@
                     <% _.forEach(documentationItem.items, function(categoryItem) { %>
                     <li>
                         <a
-                            class="<%- categoryItem.path === currentPath ? 'active' : '' %>"
+                            class="<%- categoryItem.path === currentPath ? 'sd-active' : '' %>"
                             href="<%- baseUrl %>/docs/<%- categoryItem.path %>"
                         >
                             <%- categoryItem.label %>
@@ -42,7 +42,7 @@
         mobileCloseButton.addEventListener("mousedown", e => {
             e.preventDefault();
 
-            document.body.classList.remove("active-mobile-sidebar");
+            document.body.classList.remove("sd-active-mobile-sidebar");
         });
     </script>
 </div>

--- a/src/templates/sidebar/index.ts
+++ b/src/templates/sidebar/index.ts
@@ -1,10 +1,10 @@
 /**
  * Auto-generated file from build/generate-export-files.js
  */
-const template = `<div class="sidebar">
-    <div class="mobile-control">
+const template = `<div class="sd-sidebar">
+    <div class="sd-mobile-control">
         <span><%- projectTitle %></span>
-        <button id="mobileClose" class="mobile-toggle">
+        <button id="mobileClose" class="sd-mobile-toggle">
             <svg viewBox="0 0 15 15" width="21" height="21">
                 <g stroke="#ccd0d5" stroke-width="1.2">
                     <path d="M.75.75l13.5 13.5M14.25.75L.75 14.25"></path>
@@ -17,7 +17,7 @@ const template = `<div class="sidebar">
             <% _.forEach(sidebar.links, function(documentationItem) { %>
             <li>
                 <a
-                    class="<%- documentationItem.path === currentPath ? 'active' : '' %>"
+                    class="<%- documentationItem.path === currentPath ? 'sd-active' : '' %>"
                     href="<%- baseUrl %>/docs/<%- documentationItem.path %>"
                 >
                     <%- documentationItem.label %>
@@ -27,7 +27,7 @@ const template = `<div class="sidebar">
                     <% _.forEach(documentationItem.items, function(categoryItem) { %>
                     <li>
                         <a
-                            class="<%- categoryItem.path === currentPath ? 'active' : '' %>"
+                            class="<%- categoryItem.path === currentPath ? 'sd-active' : '' %>"
                             href="<%- baseUrl %>/docs/<%- categoryItem.path %>"
                         >
                             <%- categoryItem.label %>
@@ -45,7 +45,7 @@ const template = `<div class="sidebar">
         mobileCloseButton.addEventListener("mousedown", e => {
             e.preventDefault();
 
-            document.body.classList.remove("active-mobile-sidebar");
+            document.body.classList.remove("sd-active-mobile-sidebar");
         });
     </script>
 </div>`;

--- a/src/templates/style/index.html
+++ b/src/templates/style/index.html
@@ -5,7 +5,7 @@
         padding: 0;
     }
 
-    body {
+    .static-docs {
         --sd-link-color: #ebedf0;
         --sd-accent-link-color: #fb356d;
         --sd-font-color: #f5f6f7;
@@ -15,7 +15,7 @@
         --sd-font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
         --sd-background-color-layer-1: #18191a;
         --sd-background-color-layer-2: #242526;
-        --sd-background-color-layer-3: hsla(0, 0%, 100%, 0.05);
+        --sd-background-color-layer-3: hsla(0, 0%, 100%, 0.sd-05);
         --sd-footer-background-color: #303846;
         --sd-footer-color: #ebefd0;
         --sd-footer-height: 220px;
@@ -32,7 +32,7 @@
         --sd-sidebar-link-active-background-color: var(--sd-background-color-layer-3);
         --sd-sidebar-background-color: var(--sd-background-color-layer-2);
         --sd-toolbar-background-color: var(--sd-background-color-layer-2);
-        --sd-toolbar-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
+        --sd-toolbar-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.sd-1);
         --sd-toolbar-height: 60px;
         --sd-category-border-color: #444950;
         --sd-category-background-color: var(--sd-background-color-layer-2);
@@ -50,21 +50,21 @@
         font-family: var(--sd-font-family);
     }
 
-    p {
+    .static-docs p {
         line-height: 24px;
     }
 
-    .toolbar {
+    .sd-toolbar {
         position: sticky;
         top: 0;
     }
 
-    .toolbar .section {
+    .sd-toolbar .sd-section {
         display: flex;
         padding: 0 15px;
     }
 
-    header nav {
+    .static-docs header nav {
         display: flex;
         height: var(--sd-toolbar-height);
         justify-content: space-between;
@@ -72,26 +72,26 @@
         box-shadow: var(--sd-toolbar-shadow);
     }
 
-    header nav ul {
+    .static-docs header nav ul {
         display: flex;
         padding: 15px 0;
     }
 
-    header nav li {
+    .static-docs header nav li {
         padding: 0 10px;
     }
 
-    .icon {
+    .sd-icon {
         height: 20px;
         width: 18px;
         fill: var(--sd-link-color);
     }
 
-    a:hover .icon {
+    .static-docs a:hover .sd-icon {
         fill: var(--sd-accent-link-color);
     }
 
-    .sidebar {
+    .sd-sidebar {
         width: var(--sd-sidebar-width);
         min-width: var(--sd-sidebar-width);
         border-right: 1px solid var(--sd-sidebar-border-color);
@@ -99,28 +99,28 @@
         overflow: auto;
     }
 
-    .sidebar nav {
+    .sd-sidebar nav {
         margin-inline-start: -20px;
     }
 
-    .sidebar nav > ul {
+    .sd-sidebar nav > ul {
         margin: 20px 0;
     }
 
-    .sidebar a {
+    .sd-sidebar a {
         display: flex;
-        line-height: 1.25;
+        line-height: 1.sd-25;
         flex: 1;
         padding: 10px 15px;
         border-radius: 5px;
         color: var(--sd-link-color);
     }
 
-    .sidebar .active {
+    .sd-sidebar .sd-active {
         background: var(--sd-sidebar-link-active-background-color);
     }
 
-    .category {
+    .sd-category {
         margin: var(--sd-spacing-vertical) 0;
         padding: 0;
         display: flex;
@@ -129,68 +129,68 @@
         flex-wrap: wrap;
     }
 
-    .category li {
+    .sd-category li {
         border: 1px solid var(--sd-category-border-color);
         background: var(--sd-category-background-color);
-        box-shadow: 0 1.5px 3px 0 rgb(0 0 0 / 15%);
+        box-shadow: 0 1.sd-5px 3px 0 rgb(0 0 0 / 15%);
         padding: 20px;
         border-radius: var(--sd-category-border-radius);
         width: 200px;
     }
 
-    .category li a {
+    .sd-category li a {
         color: var(--sd-link-color);
     }
 
-    .category a,
-    .toolbar a,
-    .sidebar a,
+    .sd-category a,
+    .sd-toolbar a,
+    .sd-sidebar a,
     footer a {
         display: flex;
         align-items: center;
         column-gap: 5px;
     }
 
-    a {
+    .static-docs a {
         color: var(--sd-link-color);
         text-decoration: none;
     }
 
-    a:hover {
+    .static-docs a:hover {
         color: var(--sd-accent-link-color);
     }
 
-    main {
+    .static-docs main {
         display: flex;
         margin: 0 25px 0 5px;
     }
 
-    main > .container {
+    .static-docs main > .sd-container {
         padding: 25px;
     }
 
-    main div a {
+    .static-docs main div a {
         color: var(--sd-accent-link-color);
     }
 
-    main ul {
+    .static-docs main ul {
         padding-inline-start: 20px;
         padding-inline-end: 20px;
     }
 
-    .container {
+    .sd-container {
         max-width: 900px;
     }
 
-    .content ul {
+    .sd-content ul {
         list-style: inherit;
     }
 
-    .frontpage {
+    .sd-frontpage {
         margin: var(--sd-spacing-vertical);
     }
 
-    .card-container {
+    .sd-card-container {
         display: flex;
         flex-wrap: wrap;
         column-gap: 15px;
@@ -199,22 +199,22 @@
         margin: 50px 0;
     }
 
-    .card {
+    .sd-card {
         background: var(--sd-background-color-layer-3);
         border-radius: 5px;
         padding: 0 20px;
         width: 300px;
     }
 
-    .mobile-overlay {
+    .sd-mobile-overlay {
         display: none;
     }
 
-    .mobile-control {
+    .sd-mobile-control {
         display: none;
     }
 
-    .mobile-toggle {
+    .sd-mobile-toggle {
         background: none;
         border: none;
         color: inherit;
@@ -224,21 +224,21 @@
         display: none;
     }
 
-    ul {
+    .static-docs ul {
         padding: 0;
         margin: 0;
         list-style: none;
     }
 
-    li {
+    .static-docs li {
         line-height: 26px;
     }
 
-    h1 {
+    .static-docs h1 {
         margin: var(--sd-spacing-vertical) 0;
     }
 
-    footer {
+    .static-docs footer {
         display: flex;
         flex-direction: column;
         justify-content: space-between;
@@ -249,23 +249,23 @@
         color: var(--sd-footer-color);
     }
 
-    footer .links {
+    .static-docs footer .sd-links {
         display: flex;
         justify-content: space-around;
         column-gap: 15px;
     }
 
-    footer .links svg {
+    .static-docs footer .sd-links svg {
         margin-inline-start: 5px;
         position: relative;
         top: 1px;
     }
 
-    footer .copyright {
+    .static-docs footer .sd-copyright {
         text-align: center;
     }
 
-    table {
+    .static-docs table {
         border-collapse: collapse;
         display: block;
         margin: var(--sd-spacing-vertical) 0;
@@ -273,7 +273,7 @@
         box-sizing: border-box;
     }
 
-    table caption {
+    .static-docs table caption {
         display: inline-block;
         margin-block-end: 15px;
         background: var(--sd-table-caption-background-color);
@@ -281,34 +281,34 @@
         padding: 5px 10px;
     }
 
-    table thead tr {
+    .static-docs table thead tr {
         border-bottom: 2px solid var(--sd-table-border-color);
     }
 
-    table tr {
+    .static-docs table tr {
         background-color: var(--sd-table-background);
         border-top: var(--sd-table-border-width) solid var(--sd-table-border-color);
     }
 
-    table th {
+    .static-docs table th {
         background-color: var(--sd-table-head-background);
         color: var(--sd-table-head-color);
         font-weight: var(--sd-table-head-font-weight);
     }
 
-    table td,
-    table th {
+    .static-docs table td,
+    .static-docs table th {
         border: var(--sd-table-border-width) solid var(--sd-table-border-color);
         padding: var(--sd-table-cell-padding);
     }
 
-    pre code {
+    .static-docs pre code {
         display: block;
         padding: 16px;
         background-color: var(--sd-code-block-background);
     }
 
-    code {
+    .static-docs code {
         background-color: var(--sd-code-background);
         border: .1rem solid rgba(0,0,0,.1);
         border-radius: var(--sd-code-border-radius);
@@ -317,21 +317,21 @@
     }
 
     @media (max-width: 996px) {
-        .mobile-control {
+        .sd-mobile-control {
             display: flex;
             padding: 15px;
             justify-content: space-between;
         }
 
-        .docs .mobile-toggle {
+        .static-docs .sd-mobile-toggle {
             display: block;
         }
 
-        .sidebar {
+        .sd-sidebar {
             margin-inline-start: calc((-1 * var(--sd-sidebar-width)) - 6px);
         }
 
-        .active-mobile-sidebar .sidebar {
+        .sd-active-mobile-sidebar .sd-sidebar {
             margin-inline-start: -5px;
             padding-inline-start: 5px;
             position: absolute;
@@ -341,18 +341,18 @@
             z-index: 1;
         }
 
-        .active-mobile-sidebar .mobile-overlay {
+        .sd-active-mobile-sidebar .sd-mobile-overlay {
             position: absolute;
             top: 0;
             bottom: 0;
             left: 0;
             right: 0;
             background: black;
-            opacity: 0.8;
+            opacity: 0.sd-8;
             z-index: 1;
         }
 
-        footer .links {
+        .static-docs footer .sd-links {
             flex-direction: column;
         }
     }

--- a/src/templates/style/index.ts
+++ b/src/templates/style/index.ts
@@ -8,7 +8,7 @@ const template = `<style>
         padding: 0;
     }
 
-    body {
+    .static-docs {
         --sd-link-color: #ebedf0;
         --sd-accent-link-color: #fb356d;
         --sd-font-color: #f5f6f7;
@@ -18,7 +18,7 @@ const template = `<style>
         --sd-font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
         --sd-background-color-layer-1: #18191a;
         --sd-background-color-layer-2: #242526;
-        --sd-background-color-layer-3: hsla(0, 0%, 100%, 0.05);
+        --sd-background-color-layer-3: hsla(0, 0%, 100%, 0.sd-05);
         --sd-footer-background-color: #303846;
         --sd-footer-color: #ebefd0;
         --sd-footer-height: 220px;
@@ -35,7 +35,7 @@ const template = `<style>
         --sd-sidebar-link-active-background-color: var(--sd-background-color-layer-3);
         --sd-sidebar-background-color: var(--sd-background-color-layer-2);
         --sd-toolbar-background-color: var(--sd-background-color-layer-2);
-        --sd-toolbar-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
+        --sd-toolbar-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.sd-1);
         --sd-toolbar-height: 60px;
         --sd-category-border-color: #444950;
         --sd-category-background-color: var(--sd-background-color-layer-2);
@@ -53,21 +53,21 @@ const template = `<style>
         font-family: var(--sd-font-family);
     }
 
-    p {
+    .static-docs p {
         line-height: 24px;
     }
 
-    .toolbar {
+    .sd-toolbar {
         position: sticky;
         top: 0;
     }
 
-    .toolbar .section {
+    .sd-toolbar .sd-section {
         display: flex;
         padding: 0 15px;
     }
 
-    header nav {
+    .static-docs header nav {
         display: flex;
         height: var(--sd-toolbar-height);
         justify-content: space-between;
@@ -75,26 +75,26 @@ const template = `<style>
         box-shadow: var(--sd-toolbar-shadow);
     }
 
-    header nav ul {
+    .static-docs header nav ul {
         display: flex;
         padding: 15px 0;
     }
 
-    header nav li {
+    .static-docs header nav li {
         padding: 0 10px;
     }
 
-    .icon {
+    .sd-icon {
         height: 20px;
         width: 18px;
         fill: var(--sd-link-color);
     }
 
-    a:hover .icon {
+    .static-docs a:hover .sd-icon {
         fill: var(--sd-accent-link-color);
     }
 
-    .sidebar {
+    .sd-sidebar {
         width: var(--sd-sidebar-width);
         min-width: var(--sd-sidebar-width);
         border-right: 1px solid var(--sd-sidebar-border-color);
@@ -102,28 +102,28 @@ const template = `<style>
         overflow: auto;
     }
 
-    .sidebar nav {
+    .sd-sidebar nav {
         margin-inline-start: -20px;
     }
 
-    .sidebar nav > ul {
+    .sd-sidebar nav > ul {
         margin: 20px 0;
     }
 
-    .sidebar a {
+    .sd-sidebar a {
         display: flex;
-        line-height: 1.25;
+        line-height: 1.sd-25;
         flex: 1;
         padding: 10px 15px;
         border-radius: 5px;
         color: var(--sd-link-color);
     }
 
-    .sidebar .active {
+    .sd-sidebar .sd-active {
         background: var(--sd-sidebar-link-active-background-color);
     }
 
-    .category {
+    .sd-category {
         margin: var(--sd-spacing-vertical) 0;
         padding: 0;
         display: flex;
@@ -132,68 +132,68 @@ const template = `<style>
         flex-wrap: wrap;
     }
 
-    .category li {
+    .sd-category li {
         border: 1px solid var(--sd-category-border-color);
         background: var(--sd-category-background-color);
-        box-shadow: 0 1.5px 3px 0 rgb(0 0 0 / 15%);
+        box-shadow: 0 1.sd-5px 3px 0 rgb(0 0 0 / 15%);
         padding: 20px;
         border-radius: var(--sd-category-border-radius);
         width: 200px;
     }
 
-    .category li a {
+    .sd-category li a {
         color: var(--sd-link-color);
     }
 
-    .category a,
-    .toolbar a,
-    .sidebar a,
+    .sd-category a,
+    .sd-toolbar a,
+    .sd-sidebar a,
     footer a {
         display: flex;
         align-items: center;
         column-gap: 5px;
     }
 
-    a {
+    .static-docs a {
         color: var(--sd-link-color);
         text-decoration: none;
     }
 
-    a:hover {
+    .static-docs a:hover {
         color: var(--sd-accent-link-color);
     }
 
-    main {
+    .static-docs main {
         display: flex;
         margin: 0 25px 0 5px;
     }
 
-    main > .container {
+    .static-docs main > .sd-container {
         padding: 25px;
     }
 
-    main div a {
+    .static-docs main div a {
         color: var(--sd-accent-link-color);
     }
 
-    main ul {
+    .static-docs main ul {
         padding-inline-start: 20px;
         padding-inline-end: 20px;
     }
 
-    .container {
+    .sd-container {
         max-width: 900px;
     }
 
-    .content ul {
+    .sd-content ul {
         list-style: inherit;
     }
 
-    .frontpage {
+    .sd-frontpage {
         margin: var(--sd-spacing-vertical);
     }
 
-    .card-container {
+    .sd-card-container {
         display: flex;
         flex-wrap: wrap;
         column-gap: 15px;
@@ -202,22 +202,22 @@ const template = `<style>
         margin: 50px 0;
     }
 
-    .card {
+    .sd-card {
         background: var(--sd-background-color-layer-3);
         border-radius: 5px;
         padding: 0 20px;
         width: 300px;
     }
 
-    .mobile-overlay {
+    .sd-mobile-overlay {
         display: none;
     }
 
-    .mobile-control {
+    .sd-mobile-control {
         display: none;
     }
 
-    .mobile-toggle {
+    .sd-mobile-toggle {
         background: none;
         border: none;
         color: inherit;
@@ -227,21 +227,21 @@ const template = `<style>
         display: none;
     }
 
-    ul {
+    .static-docs ul {
         padding: 0;
         margin: 0;
         list-style: none;
     }
 
-    li {
+    .static-docs li {
         line-height: 26px;
     }
 
-    h1 {
+    .static-docs h1 {
         margin: var(--sd-spacing-vertical) 0;
     }
 
-    footer {
+    .static-docs footer {
         display: flex;
         flex-direction: column;
         justify-content: space-between;
@@ -252,23 +252,23 @@ const template = `<style>
         color: var(--sd-footer-color);
     }
 
-    footer .links {
+    .static-docs footer .sd-links {
         display: flex;
         justify-content: space-around;
         column-gap: 15px;
     }
 
-    footer .links svg {
+    .static-docs footer .sd-links svg {
         margin-inline-start: 5px;
         position: relative;
         top: 1px;
     }
 
-    footer .copyright {
+    .static-docs footer .sd-copyright {
         text-align: center;
     }
 
-    table {
+    .static-docs table {
         border-collapse: collapse;
         display: block;
         margin: var(--sd-spacing-vertical) 0;
@@ -276,7 +276,7 @@ const template = `<style>
         box-sizing: border-box;
     }
 
-    table caption {
+    .static-docs table caption {
         display: inline-block;
         margin-block-end: 15px;
         background: var(--sd-table-caption-background-color);
@@ -284,34 +284,34 @@ const template = `<style>
         padding: 5px 10px;
     }
 
-    table thead tr {
+    .static-docs table thead tr {
         border-bottom: 2px solid var(--sd-table-border-color);
     }
 
-    table tr {
+    .static-docs table tr {
         background-color: var(--sd-table-background);
         border-top: var(--sd-table-border-width) solid var(--sd-table-border-color);
     }
 
-    table th {
+    .static-docs table th {
         background-color: var(--sd-table-head-background);
         color: var(--sd-table-head-color);
         font-weight: var(--sd-table-head-font-weight);
     }
 
-    table td,
-    table th {
+    .static-docs table td,
+    .static-docs table th {
         border: var(--sd-table-border-width) solid var(--sd-table-border-color);
         padding: var(--sd-table-cell-padding);
     }
 
-    pre code {
+    .static-docs pre code {
         display: block;
         padding: 16px;
         background-color: var(--sd-code-block-background);
     }
 
-    code {
+    .static-docs code {
         background-color: var(--sd-code-background);
         border: .1rem solid rgba(0,0,0,.1);
         border-radius: var(--sd-code-border-radius);
@@ -320,21 +320,21 @@ const template = `<style>
     }
 
     @media (max-width: 996px) {
-        .mobile-control {
+        .sd-mobile-control {
             display: flex;
             padding: 15px;
             justify-content: space-between;
         }
 
-        .docs .mobile-toggle {
+        .static-docs .sd-mobile-toggle {
             display: block;
         }
 
-        .sidebar {
+        .sd-sidebar {
             margin-inline-start: calc((-1 * var(--sd-sidebar-width)) - 6px);
         }
 
-        .active-mobile-sidebar .sidebar {
+        .sd-active-mobile-sidebar .sd-sidebar {
             margin-inline-start: -5px;
             padding-inline-start: 5px;
             position: absolute;
@@ -344,18 +344,18 @@ const template = `<style>
             z-index: 1;
         }
 
-        .active-mobile-sidebar .mobile-overlay {
+        .sd-active-mobile-sidebar .sd-mobile-overlay {
             position: absolute;
             top: 0;
             bottom: 0;
             left: 0;
             right: 0;
             background: black;
-            opacity: 0.8;
+            opacity: 0.sd-8;
             z-index: 1;
         }
 
-        footer .links {
+        .static-docs footer .sd-links {
             flex-direction: column;
         }
     }

--- a/src/templates/toolbar/index.html
+++ b/src/templates/toolbar/index.html
@@ -1,7 +1,7 @@
-<header class="toolbar">
+<header class="sd-toolbar">
     <nav>
-        <div class="section">
-            <button id="mobileOpen" class="mobile-toggle">
+        <div class="sd-section">
+            <button id="mobileOpen" class="sd-mobile-toggle">
                 <svg width="30" height="30" viewBox="0 0 30 30" aria-hidden="true">
                     <path
                         stroke="currentColor"
@@ -26,14 +26,14 @@
                 <% _.forEach(links, function(link) { %><li><a href="<%- link.href %>"><%- link.title %></a></li><% }); %>
             </ul>
         </div>
-        <div class="section">
+        <div class="sd-section">
             <ul>
                 <li>
                     <a href="<%- githubUrl %>" target="_blank">
                         <span>GitHub</span>
                         <svg
                             xmlns="http://www.w3.org/2000/svg"
-                            class="icon icon-github"
+                            class="sd-icon sd-icon-github"
                             viewBox="0 0 19 20"
                         >
                             <path
@@ -50,7 +50,7 @@
         mobileOpenButton.addEventListener("mousedown", e => {
             e.preventDefault();
 
-            document.body.classList.add("active-mobile-sidebar");
+            document.body.classList.add("sd-active-mobile-sidebar");
         });
     </script>
 </header>

--- a/src/templates/toolbar/index.ts
+++ b/src/templates/toolbar/index.ts
@@ -1,10 +1,10 @@
 /**
  * Auto-generated file from build/generate-export-files.js
  */
-const template = `<header class="toolbar">
+const template = `<header class="sd-toolbar">
     <nav>
-        <div class="section">
-            <button id="mobileOpen" class="mobile-toggle">
+        <div class="sd-section">
+            <button id="mobileOpen" class="sd-mobile-toggle">
                 <svg width="30" height="30" viewBox="0 0 30 30" aria-hidden="true">
                     <path
                         stroke="currentColor"
@@ -29,14 +29,14 @@ const template = `<header class="toolbar">
                 <% _.forEach(links, function(link) { %><li><a href="<%- link.href %>"><%- link.title %></a></li><% }); %>
             </ul>
         </div>
-        <div class="section">
+        <div class="sd-section">
             <ul>
                 <li>
                     <a href="<%- githubUrl %>" target="_blank">
                         <span>GitHub</span>
                         <svg
                             xmlns="http://www.w3.org/2000/svg"
-                            class="icon icon-github"
+                            class="sd-icon sd-icon-github"
                             viewBox="0 0 19 20"
                         >
                             <path
@@ -53,7 +53,7 @@ const template = `<header class="toolbar">
         mobileOpenButton.addEventListener("mousedown", e => {
             e.preventDefault();
 
-            document.body.classList.add("active-mobile-sidebar");
+            document.body.classList.add("sd-active-mobile-sidebar");
         });
     </script>
 </header>


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This changes include:
- Adding the "static-docs" to the document and front page body elements
- Prefixes all CSS classes with "sd"
- Added CSS specificity for any non-class based styles such as html tag styles to isolate them from the global styling scope.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Find a way to change all CSS variables via the StaticDocs configuration